### PR TITLE
improvement: fix tooltips not appearing

### DIFF
--- a/save-game/interface/UIItem.tscn
+++ b/save-game/interface/UIItem.tscn
@@ -27,6 +27,7 @@ one_shot = true
 [node name="MarginContainer" type="MarginContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 custom_constants/margin_right = 20
 custom_constants/margin_left = 20
 


### PR DESCRIPTION
Change UIItem/MarginContainer mouse_filter to PASS
Allows UIItem panel to properly communicate mouse_entered events

- [ x ] The commit message follows our guidelines.
- For bug fixes and features:
    - [ x ] You tested the changes.

**What kind of change does this PR introduce?**
Bug fix

**Does this PR introduce a breaking change?**
No

## New feature or change ##
Modifies UIItem's child node, MarginContainer, which contains the sprite and label text for the item, such that mouse events are passed to the parent UIItem panel node, allowing the existing signal chaining to trigger as expected.

**What is the current behavior?** 
Tooltips do not appear in the inventory when hovering over items.

**What is the new behavior?**
Tooltips appear after the TooltipTimer times out when triggered by a mouse_entered event.

<img width="962" alt="image" src="https://user-images.githubusercontent.com/5360012/176314685-b1caaa2a-8f21-4b42-a9e8-8b7b2260f553.png">
