### PR TITLE
Load Save workaround: Read as bytes instead of text

### DIFF
--- a/save-game/resources/SaveGame.gd
+++ b/save-game/resources/SaveGame.gd
@@ -49,13 +49,13 @@ static func load_savegame() -> Resource:
 	# We copy the SaveGame resource's data to a temporary file, load that file
 	# as a resource, and make it take over the save game.
 
-	# We first load the save game resource's content as text and store it.
+	# We first load the save game resource's content as a byte array and store it.
 	var file := File.new()
 	if file.open(save_path, File.READ) != OK:
 		printerr("Couldn't read file " + save_path)
 		return null
 
-	var data := file.get_as_text()
+	var data := file.get_buffer(file.get_len())
 	file.close()
 
 	# Then, we generate a random file path that's not in Godot's cache.
@@ -68,7 +68,7 @@ static func load_savegame() -> Resource:
 		printerr("Couldn't write file " + tmp_file_path)
 		return null
 
-	file.store_string(data)
+	file.store_buffer(data)
 	file.close()
 
 	# We load the temporary file as a resource.


### PR DESCRIPTION
If the save file is stored as a binary .res instead of a text .tres, `file.get_as_text()` will fail and a broken temporary file will be generated.

Reading and storing as a byte array works with both text resources and binary resources.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.

**What kind of change does this PR introduce?**

It changes the workaround in the `load_savegame()` function. Instead of reading the file as text, it reads as a byte array.

**Does this PR introduce a breaking change?**

It only changes the way the temporary save file is read and stored, so no.

## New feature or change ##

**What is the current behavior?** 

Read save file as string, temporarily store it as string.

**What is the new behavior?**

Read save file as binary, temporarily store it as binary.

**Other information:**

Since a whole text file is copied and stored as a binary, it will still work as an usual text file.