### PR TITLE
Fix double GDQuestVisualizationTools on HitBox and HurtBox demo

### DIFF
--- a/hitbox-hurtbox/project.godot
+++ b/hitbox-hurtbox/project.godot
@@ -49,7 +49,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gdquest_visualization_tools/2d/DebugRayCast2D.gd"
 }, {
-"base": "Reference",
+"base": "Area2D",
 "class": "GDQuestDebugDraggable",
 "language": "GDScript",
 "path": "res://nodes/GDQuestDebugDraggable.gd"
@@ -73,7 +73,7 @@ _global_script_class_icons={
 "DebugPath2D": "",
 "DebugRayCast": "",
 "DebugRayCast2D": "",
-"GDQuestDebugDraggable": "",
+"GDQuestDebugDraggable": "res://nodes/GDQuestDebugDraggable.svg",
 "HitBox": "res://nodes/HitBox.svg",
 "HurtBox": "res://nodes/HurtBox.svg"
 }
@@ -86,7 +86,6 @@ config/icon="res://icon.png"
 
 [autoload]
 
-GdQuestVisualizationTools="*res://addons/gdquest_visualization_tools/GDQuestVisualizationTools.gd"
 GDQuestVisualizationTools="*res://addons/gdquest_visualization_tools/GDQuestVisualizationTools.gd"
 
 [display]

--- a/juicy-attack/project.godot
+++ b/juicy-attack/project.godot
@@ -80,7 +80,7 @@ config/icon="res://icon.png"
 
 [autoload]
 
-GdQuestVisualizationTools="*res://addons/gdquest_visualization_tools/GDQuestVisualizationTools.gd"
+GDQuestVisualizationTools="*res://addons/gdquest_visualization_tools/GDQuestVisualizationTools.gd"
 EventBus="*res://autoload/EventBus.gd"
 
 [display]


### PR DESCRIPTION
- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.


Related issue (if applicable): 0

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
When testing the "HitBox and  HurtBox" demo, I noticed there were two "Visualization Tools" nodes instantiated in the live scene (a "GdQuest[...]" and a "GDQuest[...]" one). It didn't affect the scene, but it was the same script being instantiated twice in Autoload with different names, so I removed the "GdQuest[...]" autoload (since it didn't follow the name convention of the project). 

I took the liberty of checking the other demos for this same error, and I changed the "Juicy-Attack" autoload name to also follow the "GDQuest" name convention. If this is not the correct name, I can change it back for both demos!


**Does this PR introduce a breaking change?**
No.